### PR TITLE
Fix serialization of Track.number and Route.number

### DIFF
--- a/src/gpx/route.py
+++ b/src/gpx/route.py
@@ -104,7 +104,7 @@ class Route(Element, PointsMutableSequenceMixin, PointsStatisticsMixin):
 
         if self.number is not None:
             number = etree.SubElement(route, "number", nsmap=self._nsmap)
-            number.text = self.number
+            number.text = str(self.number)
 
         if self.type is not None:
             _type = etree.SubElement(route, "type", nsmap=self._nsmap)

--- a/src/gpx/track.py
+++ b/src/gpx/track.py
@@ -122,7 +122,7 @@ class Track(Element):
 
         if self.number is not None:
             number = etree.SubElement(track, "number", nsmap=self._nsmap)
-            number.text = self.number
+            number.text = str(self.number)
 
         if self.type is not None:
             _type = etree.SubElement(track, "type", nsmap=self._nsmap)


### PR DESCRIPTION
The number field is of type int, but Element.text expects a string, so without the conversion the assigment fails:
  > TypeError: Argument must be bytes or unicode, got 'int'