### PR TITLE
Add feature parity to dataclass-based models

### DIFF
--- a/src/gpx/models/route.py
+++ b/src/gpx/models/route.py
@@ -8,10 +8,18 @@ GPX 1.1 specification.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING, overload
 
 from .base import GPXModel
 from .link import Link  # noqa: TC001
 from .waypoint import Waypoint  # noqa: TC001
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from gpx.types import Latitude, Longitude
 
 
 @dataclass(kw_only=True, slots=True)
@@ -43,3 +51,181 @@ class Route(GPXModel):
     number: int | None = None
     type: str | None = None
     rtept: list[Waypoint] = field(default_factory=list)
+
+    @property
+    def points(self) -> list[Waypoint]:
+        """Alias for rtept."""
+        return self.rtept
+
+    @overload
+    def __getitem__(self, index: int) -> Waypoint: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[Waypoint]: ...
+
+    def __getitem__(self, index: int | slice) -> Waypoint | list[Waypoint]:
+        """Get a route point by index or slice."""
+        return self.rtept[index]
+
+    def __len__(self) -> int:
+        """Return the number of route points."""
+        return len(self.rtept)
+
+    def __iter__(self) -> Iterator[Waypoint]:
+        """Iterate over route points."""
+        yield from self.rtept
+
+    @property
+    def bounds(self) -> tuple[Latitude, Longitude, Latitude, Longitude]:
+        """The bounds of the route."""
+        return (
+            min(point.lat for point in self.rtept),
+            min(point.lon for point in self.rtept),
+            max(point.lat for point in self.rtept),
+            max(point.lon for point in self.rtept),
+        )
+
+    @property
+    def total_distance(self) -> float:
+        """The total distance (in metres)."""
+        return sum(
+            point.distance_to(self.rtept[i + 1])
+            for i, point in enumerate(self.rtept[:-1])
+        )
+
+    @property
+    def distance(self) -> float:
+        """Alias of :attr:`total_distance`."""
+        return self.total_distance
+
+    @property
+    def total_duration(self) -> timedelta:
+        """The total duration."""
+        return self.rtept[0].duration_to(self.rtept[-1])
+
+    @property
+    def duration(self) -> timedelta:
+        """Alias of :attr:`total_duration`."""
+        return self.total_duration
+
+    @property
+    def moving_duration(self) -> timedelta:
+        """The moving duration.
+
+        The moving duration is the total duration with a
+        speed greater than 0.5 km/h.
+        """
+        duration = timedelta()
+        for i, point in enumerate(self.rtept[:-1]):
+            if point.speed_to(self.rtept[i + 1]) > 0.5 / 3.6:  # 0.5 km/h
+                duration += point.duration_to(self.rtept[i + 1])
+        return duration
+
+    @property
+    def avg_speed(self) -> float:
+        """The average speed (in metres / second)."""
+        return self.total_distance / self.total_duration.total_seconds()
+
+    @property
+    def speed(self) -> float:
+        """Alias of :attr:`avg_speed`."""
+        return self.avg_speed
+
+    @property
+    def avg_moving_speed(self) -> float:
+        """The average moving speed (in metres / second)."""
+        return self.total_distance / self.moving_duration.total_seconds()
+
+    @property
+    def _speeds(self) -> list[float]:
+        return [
+            point.speed_to(self.rtept[i + 1]) for i, point in enumerate(self.rtept[:-1])
+        ]
+
+    @property
+    def max_speed(self) -> float:
+        """The maximum speed (in metres / second)."""
+        return max(self._speeds)
+
+    @property
+    def min_speed(self) -> float:
+        """The minimum speed (in metres / second)."""
+        return min(self._speeds)
+
+    @property
+    def speed_profile(self) -> list[tuple[datetime, float]]:
+        """The speed profile.
+
+        The speed profile is a list of (timestamp, speed) tuples.
+        """
+        return [
+            (point.time, point.speed_to(self.rtept[i + 1]))
+            for i, point in enumerate(self.rtept[:-1])
+            if point.time is not None
+        ]
+
+    @property
+    def _points_with_ele(self) -> list[Waypoint]:
+        return [point for point in self.rtept if point.ele is not None]
+
+    @property
+    def _eles(self) -> list[Decimal]:
+        return [point.ele for point in self.rtept if point.ele is not None]
+
+    @property
+    def avg_elevation(self) -> Decimal:
+        """The average elevation (in metres)."""
+        return sum(self._eles, Decimal(0)) / len(self._eles)
+
+    @property
+    def elevation(self) -> Decimal:
+        """Alias of :attr:`avg_elevation`."""
+        return self.avg_elevation
+
+    @property
+    def max_elevation(self) -> Decimal:
+        """The maximum elevation (in metres)."""
+        return max(self._eles)
+
+    @property
+    def min_elevation(self) -> Decimal:
+        """The minimum elevation (in metres)."""
+        return min(self._eles)
+
+    @property
+    def diff_elevation(self) -> Decimal:
+        """The difference in elevation (in metres)."""
+        return self.max_elevation - self.min_elevation
+
+    @property
+    def _gains(self) -> list[Decimal]:
+        return [
+            point.gain_to(self._points_with_ele[i + 1])
+            for i, point in enumerate(self._points_with_ele[:-1])
+        ]
+
+    @property
+    def total_ascent(self) -> Decimal:
+        """The total ascent (in metres)."""
+        return sum([gain for gain in self._gains if gain > 0], Decimal(0))
+
+    @property
+    def total_descent(self) -> Decimal:
+        """The total descent (in metres)."""
+        return abs(sum([gain for gain in self._gains if gain < 0], Decimal(0)))
+
+    @property
+    def elevation_profile(self) -> list[tuple[float, Decimal]]:
+        """The elevation profile.
+
+        The elevation profile is a list of (distance, elevation) tuples.
+        """
+        distance = 0.0
+        profile = []
+        if self._points_with_ele[0].ele is not None:
+            profile.append((distance, self._points_with_ele[0].ele))
+        for i, point in enumerate(self._points_with_ele[1:], 1):
+            if point.ele is not None:
+                distance += self._points_with_ele[i - 1].distance_to(point)
+                profile.append((distance, point.ele))
+        return profile

--- a/src/gpx/models/track.py
+++ b/src/gpx/models/track.py
@@ -7,10 +7,18 @@ describing a path, following the GPX 1.1 specification.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING, overload
 
 from .base import GPXModel
 from .link import Link  # noqa: TC001
 from .track_segment import TrackSegment  # noqa: TC001
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from gpx.types import Latitude, Longitude
 
 
 @dataclass(kw_only=True, slots=True)
@@ -41,3 +49,159 @@ class Track(GPXModel):
     number: int | None = None
     type: str | None = None
     trkseg: list[TrackSegment] = field(default_factory=list)
+
+    @property
+    def segments(self) -> list[TrackSegment]:
+        """Alias for trkseg."""
+        return self.trkseg
+
+    @overload
+    def __getitem__(self, index: int) -> TrackSegment: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[TrackSegment]: ...
+
+    def __getitem__(self, index: int | slice) -> TrackSegment | list[TrackSegment]:
+        """Get a track segment by index or slice."""
+        return self.trkseg[index]
+
+    def __len__(self) -> int:
+        """Return the number of track segments."""
+        return len(self.trkseg)
+
+    def __iter__(self) -> Iterator[TrackSegment]:
+        """Iterate over track segments."""
+        yield from self.trkseg
+
+    @property
+    def bounds(self) -> tuple[Latitude, Longitude, Latitude, Longitude]:
+        """The bounds of the track."""
+        return (
+            min(trkpt.lat for trkseg in self.trkseg for trkpt in trkseg),
+            min(trkpt.lon for trkseg in self.trkseg for trkpt in trkseg),
+            max(trkpt.lat for trkseg in self.trkseg for trkpt in trkseg),
+            max(trkpt.lon for trkseg in self.trkseg for trkpt in trkseg),
+        )
+
+    @property
+    def total_distance(self) -> float:
+        """The total distance of the track (in metres)."""
+        return sum(trkseg.total_distance for trkseg in self.trkseg)
+
+    @property
+    def distance(self) -> float:
+        """Alias of :attr:`total_distance`."""
+        return self.total_distance
+
+    @property
+    def total_duration(self) -> timedelta:
+        """The total duration of the track (in seconds)."""
+        return sum([trkseg.total_duration for trkseg in self.trkseg], timedelta())
+
+    @property
+    def duration(self) -> timedelta:
+        """Alias of :attr:`total_duration`."""
+        return self.total_duration
+
+    @property
+    def moving_duration(self) -> timedelta:
+        """The moving duration of the track.
+
+        The moving duration is the total duration with a
+        speed greater than 0.5 km/h.
+        """
+        return sum([trkseg.moving_duration for trkseg in self.trkseg], timedelta())
+
+    @property
+    def avg_speed(self) -> float:
+        """The average speed of the track (in metres / second)."""
+        return self.total_distance / self.total_duration.total_seconds()
+
+    @property
+    def speed(self) -> float:
+        """Alias of :attr:`avg_speed`."""
+        return self.avg_speed
+
+    @property
+    def avg_moving_speed(self) -> float:
+        """The average moving speed of the track (in metres / second)."""
+        return self.total_distance / self.moving_duration.total_seconds()
+
+    @property
+    def max_speed(self) -> float:
+        """The maximum speed of the track (in metres / second)."""
+        return max(trkseg.max_speed for trkseg in self.trkseg)
+
+    @property
+    def min_speed(self) -> float:
+        """The minimum speed of the track (in metres / second)."""
+        return min(trkseg.min_speed for trkseg in self.trkseg)
+
+    @property
+    def speed_profile(self) -> list[tuple[datetime, float]]:
+        """The speed profile of the track.
+
+        The speed profile is a list of (timestamp, speed) tuples.
+        """
+        profile = []
+        for trkseg in self.trkseg:
+            profile += trkseg.speed_profile
+        return profile
+
+    @property
+    def avg_elevation(self) -> Decimal:
+        """The average elevation (in metres)."""
+        _eles = [
+            trkpt.ele
+            for trkseg in self.trkseg
+            for trkpt in trkseg
+            if trkpt.ele is not None
+        ]
+        return sum(_eles, Decimal(0)) / len(_eles)
+
+    @property
+    def elevation(self) -> Decimal:
+        """Alias of :attr:`avg_elevation`."""
+        return self.avg_elevation
+
+    @property
+    def max_elevation(self) -> Decimal:
+        """The maximum elevation of the track (in metres)."""
+        return max(trkseg.max_elevation for trkseg in self.trkseg)
+
+    @property
+    def min_elevation(self) -> Decimal:
+        """The minimum elevation of the track (in metres)."""
+        return min(trkseg.min_elevation for trkseg in self.trkseg)
+
+    @property
+    def diff_elevation(self) -> Decimal:
+        """The difference in elevation of the track (in metres)."""
+        return self.max_elevation - self.min_elevation
+
+    @property
+    def total_ascent(self) -> Decimal:
+        """The total ascent of the track (in metres)."""
+        return sum([trkseg.total_ascent for trkseg in self.trkseg], Decimal(0))
+
+    @property
+    def total_descent(self) -> Decimal:
+        """The total descent of the track (in metres)."""
+        return abs(sum([trkseg.total_descent for trkseg in self.trkseg], Decimal(0)))
+
+    @property
+    def elevation_profile(self) -> list[tuple[float, Decimal]]:
+        """The elevation profile of the track.
+
+        The elevation profile is a list of (distance, elevation) tuples.
+        """
+        distance = 0.0
+        profile = []
+        if self.trkseg[0]._points_with_ele[0].ele is not None:
+            profile.append((distance, self.trkseg[0]._points_with_ele[0].ele))
+        for trkseg in self.trkseg:
+            for i, point in enumerate(trkseg._points_with_ele[1:], 1):
+                if point.ele is not None:
+                    distance += trkseg._points_with_ele[i - 1].distance_to(point)
+                    profile.append((distance, point.ele))
+        return profile

--- a/src/gpx/models/track_segment.py
+++ b/src/gpx/models/track_segment.py
@@ -7,9 +7,17 @@ which are logically connected in order, following the GPX 1.1 specification.
 from __future__ import annotations
 
 from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING, overload
 
 from .base import GPXModel
 from .waypoint import Waypoint  # noqa: TC001
+
+if TYPE_CHECKING:
+    from collections.abc import Iterator
+
+    from gpx.types import Latitude, Longitude
 
 
 @dataclass(kw_only=True, slots=True)
@@ -29,3 +37,181 @@ class TrackSegment(GPXModel):
     _tag = "trkseg"
 
     trkpt: list[Waypoint] = field(default_factory=list)
+
+    @property
+    def points(self) -> list[Waypoint]:
+        """Alias for trkpt."""
+        return self.trkpt
+
+    @overload
+    def __getitem__(self, index: int) -> Waypoint: ...
+
+    @overload
+    def __getitem__(self, index: slice) -> list[Waypoint]: ...
+
+    def __getitem__(self, index: int | slice) -> Waypoint | list[Waypoint]:
+        """Get a track point by index or slice."""
+        return self.trkpt[index]
+
+    def __len__(self) -> int:
+        """Return the number of track points."""
+        return len(self.trkpt)
+
+    def __iter__(self) -> Iterator[Waypoint]:
+        """Iterate over track points."""
+        yield from self.trkpt
+
+    @property
+    def bounds(self) -> tuple[Latitude, Longitude, Latitude, Longitude]:
+        """The bounds of the track segment."""
+        return (
+            min(point.lat for point in self.trkpt),
+            min(point.lon for point in self.trkpt),
+            max(point.lat for point in self.trkpt),
+            max(point.lon for point in self.trkpt),
+        )
+
+    @property
+    def total_distance(self) -> float:
+        """The total distance (in metres)."""
+        return sum(
+            point.distance_to(self.trkpt[i + 1])
+            for i, point in enumerate(self.trkpt[:-1])
+        )
+
+    @property
+    def distance(self) -> float:
+        """Alias of :attr:`total_distance`."""
+        return self.total_distance
+
+    @property
+    def total_duration(self) -> timedelta:
+        """The total duration."""
+        return self.trkpt[0].duration_to(self.trkpt[-1])
+
+    @property
+    def duration(self) -> timedelta:
+        """Alias of :attr:`total_duration`."""
+        return self.total_duration
+
+    @property
+    def moving_duration(self) -> timedelta:
+        """The moving duration.
+
+        The moving duration is the total duration with a
+        speed greater than 0.5 km/h.
+        """
+        duration = timedelta()
+        for i, point in enumerate(self.trkpt[:-1]):
+            if point.speed_to(self.trkpt[i + 1]) > 0.5 / 3.6:  # 0.5 km/h
+                duration += point.duration_to(self.trkpt[i + 1])
+        return duration
+
+    @property
+    def avg_speed(self) -> float:
+        """The average speed (in metres / second)."""
+        return self.total_distance / self.total_duration.total_seconds()
+
+    @property
+    def speed(self) -> float:
+        """Alias of :attr:`avg_speed`."""
+        return self.avg_speed
+
+    @property
+    def avg_moving_speed(self) -> float:
+        """The average moving speed (in metres / second)."""
+        return self.total_distance / self.moving_duration.total_seconds()
+
+    @property
+    def _speeds(self) -> list[float]:
+        return [
+            point.speed_to(self.trkpt[i + 1]) for i, point in enumerate(self.trkpt[:-1])
+        ]
+
+    @property
+    def max_speed(self) -> float:
+        """The maximum speed (in metres / second)."""
+        return max(self._speeds)
+
+    @property
+    def min_speed(self) -> float:
+        """The minimum speed (in metres / second)."""
+        return min(self._speeds)
+
+    @property
+    def speed_profile(self) -> list[tuple[datetime, float]]:
+        """The speed profile.
+
+        The speed profile is a list of (timestamp, speed) tuples.
+        """
+        return [
+            (point.time, point.speed_to(self.trkpt[i + 1]))
+            for i, point in enumerate(self.trkpt[:-1])
+            if point.time is not None
+        ]
+
+    @property
+    def _points_with_ele(self) -> list[Waypoint]:
+        return [point for point in self.trkpt if point.ele is not None]
+
+    @property
+    def _eles(self) -> list[Decimal]:
+        return [point.ele for point in self.trkpt if point.ele is not None]
+
+    @property
+    def avg_elevation(self) -> Decimal:
+        """The average elevation (in metres)."""
+        return sum(self._eles, Decimal(0)) / len(self._eles)
+
+    @property
+    def elevation(self) -> Decimal:
+        """Alias of :attr:`avg_elevation`."""
+        return self.avg_elevation
+
+    @property
+    def max_elevation(self) -> Decimal:
+        """The maximum elevation (in metres)."""
+        return max(self._eles)
+
+    @property
+    def min_elevation(self) -> Decimal:
+        """The minimum elevation (in metres)."""
+        return min(self._eles)
+
+    @property
+    def diff_elevation(self) -> Decimal:
+        """The difference in elevation (in metres)."""
+        return self.max_elevation - self.min_elevation
+
+    @property
+    def _gains(self) -> list[Decimal]:
+        return [
+            point.gain_to(self._points_with_ele[i + 1])
+            for i, point in enumerate(self._points_with_ele[:-1])
+        ]
+
+    @property
+    def total_ascent(self) -> Decimal:
+        """The total ascent (in metres)."""
+        return sum([gain for gain in self._gains if gain > 0], Decimal(0))
+
+    @property
+    def total_descent(self) -> Decimal:
+        """The total descent (in metres)."""
+        return abs(sum([gain for gain in self._gains if gain < 0], Decimal(0)))
+
+    @property
+    def elevation_profile(self) -> list[tuple[float, Decimal]]:
+        """The elevation profile.
+
+        The elevation profile is a list of (distance, elevation) tuples.
+        """
+        distance = 0.0
+        profile = []
+        if self._points_with_ele[0].ele is not None:
+            profile.append((distance, self._points_with_ele[0].ele))
+        for i, point in enumerate(self._points_with_ele[1:], 1):
+            if point.ele is not None:
+                distance += self._points_with_ele[i - 1].distance_to(point)
+                profile.append((distance, point.ele))
+        return profile


### PR DESCRIPTION
This commit implements comprehensive feature parity between the Element-based
classes and the dataclass-based models, making them fully interchangeable:

**File I/O Operations:**
- Add `from_file()` and `from_string()` class methods to GPX model
- Add `to_file()` and `to_string()` instance methods to GPX model
- Include XML validation support with `validate` parameter

**Sequence Behavior:**
- Implement `__len__`, `__iter__`, and `__getitem__` for Track, Route, and
  TrackSegment
- Enable intuitive sequence operations (indexing, iteration, length)

**Convenient Aliases:**
- Add `waypoints`, `routes`, `tracks` properties to GPX (aliases for wpt, rte, trk)
- Add `segments` property to Track (alias for trkseg)
- Add `points` property to TrackSegment and Route (aliases for trkpt, rtept)

**Metadata Proxies:**
- Add read-only proxy properties to GPX for metadata fields (name, desc, author,
  copyright, links, time, keywords, bounds)

**Statistics Properties:**
- Implement comprehensive statistics for TrackSegment and Route:
  - Distance/duration metrics (total_distance, total_duration, moving_duration)
  - Speed metrics (avg_speed, avg_moving_speed, max_speed, min_speed, speed_profile)
  - Elevation metrics (avg_elevation, max_elevation, min_elevation, diff_elevation,
    total_ascent, total_descent, elevation_profile)
  - Bounds calculation
- Implement aggregated statistics for Track across all segments

**Additional Improvements:**
- Move imports into TYPE_CHECKING blocks where appropriate
- Use absolute imports for parent module imports
- Maintain full backward compatibility with Element-based classes

All 300 existing tests pass without modification.