### PR TITLE
Refactor complex code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,10 @@ The **third number** is for emergencies when we need to start branches for older
 - GPX Extensions support: Added `Extensions` class for handling GPX extension elements from any XML namespace (e.g., Garmin's `TrackPointExtension`). Extensions are now parsed, preserved, and serialized during round-trip processing, enabling lossless handling of vendor-specific data like heart rate, cadence, temperature, etc.
 - New `extensions` field on all models that support extensions per the GPX 1.1 spec: `GPX`, `Metadata`, `Waypoint`, `Track`, `TrackSegment`, and `Route`.
 
+### Changed
+
+- Refactored `parse_from_xml()` function in `utils.py` for improved clarity and maintainability by extracting repetitive logic into focused helper functions (`_parse_list_elements`, `_parse_single_value`, `_parse_single_element`). This reduces code complexity while maintaining identical behavior.
+
 ### Fixed
 
 - EWKB format parsing now correctly handles Z coordinates by checking the EWKB flag before the ISO WKB flag.


### PR DESCRIPTION
Extract repetitive XML parsing logic into focused helper functions:
- _parse_list_elements: Parse lists of child elements
- _parse_single_value: Convert text to typed values
- _parse_single_element: Parse single optional elements

This refactoring:
- Reduces code complexity (resolves C901, PLR0912 warnings)
- Eliminates duplicate code patterns
- Improves maintainability and readability
- Maintains identical behavior (all 573 tests pass)