### PR TITLE
remove remove_encoding_from_string step from from_string method - also fixes #59

### DIFF
--- a/src/gpx/convert.py
+++ b/src/gpx/convert.py
@@ -58,7 +58,8 @@ def from_string(gpx_str: str) -> GPX:
     namespaces = extract_namespaces_from_string(gpx_str)
 
     # ET.fromstring() does not support encoding declarations in the string
-    gpx_str = remove_encoding_from_string(gpx_str)
+    # - it seems to support them now!
+    # gpx_str = remove_encoding_from_string(gpx_str)
     element = ET.fromstring(gpx_str)
 
     gpx = GPX.from_xml(element)

--- a/src/gpx/convert.py
+++ b/src/gpx/convert.py
@@ -17,7 +17,7 @@ from .route import Route
 from .track import Track
 from .track_segment import TrackSegment
 from .types import Latitude, Longitude, SupportsGeoInterface
-from .utils import extract_namespaces_from_string, remove_encoding_from_string
+from .utils import extract_namespaces_from_string
 from .waypoint import Waypoint
 
 #: WKB geometry type codes
@@ -57,9 +57,6 @@ def from_string(gpx_str: str) -> GPX:
     # Extract namespace prefixes before parsing (ElementTree loses this info)
     namespaces = extract_namespaces_from_string(gpx_str)
 
-    # ET.fromstring() does not support encoding declarations in the string
-    # - it seems to support them now!
-    # gpx_str = remove_encoding_from_string(gpx_str)
     element = ET.fromstring(gpx_str)
 
     gpx = GPX.from_xml(element)

--- a/src/gpx/utils.py
+++ b/src/gpx/utils.py
@@ -93,19 +93,6 @@ def _ns_tag(tag: str, element: ET.Element) -> str:
     return tag
 
 
-def remove_encoding_from_string(s: str) -> str:
-    """Remove encoding declarations (e.g. encoding="utf-8") from the string, if any.
-
-    Args:
-        s: The string.
-
-    Returns:
-        The string with any encoding declarations removed.
-
-    """
-    return re.sub(r"(encoding=[\"\'].+[\"\'])", "", s)
-
-
 def from_isoformat(dt_str: str) -> dt.datetime:
     """Convert a string in ISO 8601 format to a `datetime` object."""
     return dt.datetime.fromisoformat(dt_str)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -18,69 +18,8 @@ from gpx.utils import (
     is_list_type,
     is_optional,
     parse_from_xml,
-    remove_encoding_from_string,
     to_isoformat,
 )
-
-
-class TestRemoveEncodingFromString:
-    """Tests for the remove_encoding_from_string utility function."""
-
-    def test_removes_double_quoted_utf8_encoding(self) -> None:
-        """Test removal of double-quoted UTF-8 encoding declaration."""
-        input_str = '<?xml version="1.0" encoding="UTF-8"?>'
-        expected = '<?xml version="1.0" ?>'
-        assert remove_encoding_from_string(input_str) == expected
-
-    def test_removes_single_quoted_utf8_encoding(self) -> None:
-        """Test removal of single-quoted UTF-8 encoding declaration."""
-        input_str = "<?xml version='1.0' encoding='UTF-8'?>"
-        expected = "<?xml version='1.0' ?>"
-        assert remove_encoding_from_string(input_str) == expected
-
-    def test_removes_lowercase_utf8_encoding(self) -> None:
-        """Test removal of lowercase utf-8 encoding declaration."""
-        input_str = '<?xml version="1.0" encoding="utf-8"?>'
-        expected = '<?xml version="1.0" ?>'
-        assert remove_encoding_from_string(input_str) == expected
-
-    def test_removes_iso_8859_encoding(self) -> None:
-        """Test removal of ISO-8859-1 encoding declaration."""
-        input_str = '<?xml version="1.0" encoding="ISO-8859-1"?>'
-        expected = '<?xml version="1.0" ?>'
-        assert remove_encoding_from_string(input_str) == expected
-
-    def test_removes_windows_1252_encoding(self) -> None:
-        """Test removal of Windows-1252 encoding declaration."""
-        input_str = '<?xml version="1.0" encoding="windows-1252"?>'
-        expected = '<?xml version="1.0" ?>'
-        assert remove_encoding_from_string(input_str) == expected
-
-    def test_no_encoding_returns_unchanged(self) -> None:
-        """Test that string without encoding is returned unchanged."""
-        input_str = '<?xml version="1.0"?>'
-        assert remove_encoding_from_string(input_str) == input_str
-
-    def test_empty_string_returns_empty(self) -> None:
-        """Test that empty string returns empty."""
-        assert remove_encoding_from_string("") == ""
-
-    def test_preserves_rest_of_xml(self) -> None:
-        """Test that the rest of the XML content is preserved."""
-        input_str = """<?xml version="1.0" encoding="UTF-8"?>
-<gpx xmlns="http://www.topografix.com/GPX/1/1">
-  <wpt lat="52.5" lon="13.4"/>
-</gpx>"""
-        result = remove_encoding_from_string(input_str)
-        assert "<gpx" in result
-        assert '<wpt lat="52.5" lon="13.4"/>' in result
-        assert 'encoding="UTF-8"' not in result
-
-    def test_handles_encoding_with_spaces(self) -> None:
-        """Test handling of encoding with extra spaces."""
-        input_str = '<?xml version="1.0"  encoding="UTF-8" ?>'
-        result = remove_encoding_from_string(input_str)
-        assert 'encoding="UTF-8"' not in result
 
 
 class TestNamespaceExtraction:


### PR DESCRIPTION
with all my gps files from lots of hiking and cycling guides this step is not needed anymore.
